### PR TITLE
Update options table query

### DIFF
--- a/command.php
+++ b/command.php
@@ -45,8 +45,8 @@ function update_options_table($old_prefix, $verbose)
 {
     global $wpdb;
     $update_query = $wpdb->prepare("UPDATE `{$wpdb->prefix}options` SET option_name = %s WHERE option_name = %s LIMIT 1;",
-        $old_prefix . 'user_roles',
-        $wpdb->prefix . 'user_roles'
+        $wpdb->prefix . 'user_roles',
+        $old_prefix . 'user_roles'
     );
     if ($verbose) {
         \WP_CLI::line($update_query);


### PR DESCRIPTION
Fix for the `wp_options` table query is opposite.